### PR TITLE
Fix time conversion under Ruby 1.8.7

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,7 +27,7 @@ module Mater
         target.delete('target')
         datapoints = []
         target['datapoints'].each do |datapoint|
-          time = Time.at(datapoint[1]).to_s.split[1].gsub(/\:\d{2}$/, '')
+          time = Time.at(datapoint[1]).strftime("%H:%M")
           datapoints << {
             "title" => time,
             "value" => datapoint[0].to_i


### PR DESCRIPTION
Under Ruby 1.8.7, the default format for `Time.to_s` includes the day and month spelled out. For example:

```
irb(main):005:0> t = Time.at(1367283090).to_s
=> "Mon Apr 29 19:51:30 -0500 2013"
```

Under Ruby 1.9.3, this works fine:

```
1.9.3p194 :004 > Time.at(1367283090).to_s
 => "2013-04-29 17:51:30 -0700" 
```

The problem is easily fixed by replacing the string parsing in `app.rb` with a call to format the Time object directly.
